### PR TITLE
fix root home without user environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function homedir() {
 	}
 
 	if (process.platform === 'linux') {
-		return home || (user ? (process.getuid() === 0 ? '/root' : '/home/' + user) : null);
+		return home || (process.getuid() === 0 ? '/root' : (user ? '/home/' + user : null));
 	}
 
 	return home || null;


### PR DESCRIPTION
In some contexts (eg while synology DSM boots), the environment variables HOME LOGNAME USER etc are not set, but if process.getuid() is zero, we can still return "/root"
